### PR TITLE
Fix for a bug in RoboHydraHead.prototype.canHandle

### DIFF
--- a/lib/heads.js
+++ b/lib/heads.js
@@ -99,15 +99,18 @@ RoboHydraHead.prototype.canHandle = function(path) {
     var reqPath = this.normalizePath(this.stripGetParams(path));
     var headPath = this.normalizePath(this.mountPath ?
                                       this.mountPath : this.path);
+    var rePath = new RegExp("^" + headPath);
     if (this.mountPath) {
         if (headPath === '/') {
             return true;
         }
-        if (! reqPath.match(new RegExp("^" + headPath))) {
+        if (! reqPath.match(rePath)) {
             return false;
         }
-        return reqPath.length === headPath.length ||
-            reqPath[headPath.length] === '/';
+
+        var clearPath = reqPath.replace(rePath, "");
+        return clearPath.length === 0 ||
+            clearPath[0] === '/';
     } else {
         return reqPath.match(new RegExp("^" + headPath + "$"));
     }


### PR DESCRIPTION
There is a bug in **RoboHydraHead.prototype.canHandle**. The problem is with the following place in code:

```
return reqPath.length === headPath.length || reqPath[headPath.length] === '/';
```

If headPath value is exact string everything is working. But if headPath is RegEx it breaks. Example: 

```
exports.getBodyParts = function(conf) {
    return {
        heads: [
            new RoboHydraHeadFilesystem({
                mountPath: "\\$guic/blocks_newgui",
                documentRoot: 'blocks_newgui'
            })
        ]
    };
};
```

Because there is a '$' symbol in the path I have to escape it with '\'. As a result **headPath.length** became 2 symbols longer than **reqPath.length**, so following expression returns false:

```
 reqPath.length === headPath.length || reqPath[headPath.length] === '/'
```

and server returns 404 Not Found.

I tried to fix this problem in my branch and it looks like it's working, but I'm not entirely sure that my codestyle match yours. But I hope it will still help you to this this problem.
