### PR TITLE
Improve the chances of Robohydra finding its system-wide plugin directory.

### DIFF
--- a/lib/robohydra.js
+++ b/lib/robohydra.js
@@ -32,7 +32,8 @@ var RoboHydra = function(config) {
     this._headMap    = {};
     this.currentTest = {plugin: '*default*',
                         test:   '*default*'};
-    this._pluginLoadPath = ['robohydra/plugins',
+    this._pluginLoadPath = [__dirname + '/../plugins',
+                            'robohydra/plugins',
                             'node_modules/robohydra/plugins',
                             '/usr/local/share/robohydra/plugins',
                             '/usr/share/robohydra/plugins'];


### PR DESCRIPTION
Robohydra isn't always installed in /usr/local/share or /usr/share. For instance, on a Mac, with node.js and npm installed via Homebrew, Robohydra may be installed in `~/node_modules/robohydra`

Searching for systemwide plugins relative to `lib/robohydra.js` location improves the chances of finding them no matter how robohydra is installed.
