### PR TITLE
CORS plugin: always allow credentials

### DIFF
--- a/plugins/cors/index.js
+++ b/plugins/cors/index.js
@@ -20,6 +20,7 @@ exports.getBodyParts = function(conf) {
                 // other headers and/or methods.
                 h["access-control-max-age"] = 0;
                 h["access-control-allow-origin"] = '*';
+                h["access-control-allow-credentials"] = true;
                 if (reqH.hasOwnProperty("access-control-request-method")) {
                     h["access-control-allow-methods"] =
                         reqH["access-control-request-method"];
@@ -33,6 +34,7 @@ exports.getBodyParts = function(conf) {
                 var fakeRes = new Response().on('head', function(evt) {
                     if (req.headers.origin) {
                         evt.headers["access-control-allow-origin"] = '*';
+                        evt.headers["access-control-allow-credentials"] = true;
                     }
                 });
                 res.follow(fakeRes);


### PR DESCRIPTION
Change to include the Access-Control-Allow-Credentials header in CORS responses. This header is required to let you send requests with credentials - e.g. including cookies with requests.

More info here:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Credentials
