### PR TITLE
CORS plugin: Use origin from request instead of wildcard to support credentials

### DIFF
--- a/plugins/cors/index.js
+++ b/plugins/cors/index.js
@@ -19,7 +19,7 @@ exports.getBodyParts = function(conf) {
                 // make the browser think that the server won't accept
                 // other headers and/or methods.
                 h["access-control-max-age"] = 0;
-                h["access-control-allow-origin"] = '*';
+                h["access-control-allow-origin"] = reqH.origin ? reqH.origin : '*';
                 h["access-control-allow-credentials"] = true;
                 if (reqH.hasOwnProperty("access-control-request-method")) {
                     h["access-control-allow-methods"] =
@@ -33,7 +33,7 @@ exports.getBodyParts = function(conf) {
             } else {
                 var fakeRes = new Response().on('head', function(evt) {
                     if (req.headers.origin) {
-                        evt.headers["access-control-allow-origin"] = '*';
+                        evt.headers["access-control-allow-origin"] = req.headers.origin;
                         evt.headers["access-control-allow-credentials"] = true;
                     }
                 });


### PR DESCRIPTION
I noticed an issue with my previous PR. If you send a request with access-control-allow-credentials then the server cannot respond with a wildcard (https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials).

I've changed it to reflect the origin from the request instead.