### PR TITLE
Autoparse is ready for review!

### DIFF
--- a/lib/bufferParser.js
+++ b/lib/bufferParser.js
@@ -55,7 +55,7 @@ function getConversionParams(headers) {
     var headerSplit = headers['content-type'].split(';');
     var contentType = normalize(headerSplit[0]);
 
-    // Supports charset as a part of the 'content-type' header.
+    // Some ugly parsing to support charset as a part of the 'content-type' header.
     if (!charset && headerSplit[1]) {
         var charsetIndex = headerSplit[1].indexOf('=');
         if (charsetIndex !== -1) {

--- a/lib/bufferParser.js
+++ b/lib/bufferParser.js
@@ -17,7 +17,7 @@ function initStrategies(buffer) {
             return buffer.toString(charset);
         },
         default: function() {
-            return buffer;
+            return null;
         }
     };
 }
@@ -33,7 +33,7 @@ function initStrategies(buffer) {
 function parse(buff, headers) {
     var params = getConversionParams(headers);
     var strategies = initStrategies(buff);
-    var strategy = strategies[params.type] || strategies['default'];  
+    var strategy = strategies[params.type] || strategies['default'];
 
     try {
         return strategy(params.charset);    

--- a/lib/bufferParser.js
+++ b/lib/bufferParser.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * To extend the conversion behaviour for more headers, just add a new kvp.
+ * * Key should be the name of a header, without / and -
+ * * Value should be a function which returns the body.
+ */
+function initStrategies(buffer) {
+    return {
+        applicationjson: function(charset) {
+            return JSON.parse(buffer.toString(charset));
+        },
+        textplain: function(charset) {
+            return buffer.toString(charset);
+        },
+        texthtml: function(charset) {
+            return buffer.toString(charset);
+        },
+        default: function() {
+            return buffer;
+        }
+    };
+}
+
+/**
+ * Parses the a buffer into the expected internal type, based
+ * on standard request headers (content-type and charset). 
+ * 
+ * @param  {buffer} bodyBuffer The initial buffer value to parse.
+ * @param  {object} headers Used to select the conversion strategy.
+ * @return {object} Parsed post-body according to content-type and charset.
+ */
+function parse(bodyBuffer, headers) {
+    var params = getConversionParams(headers);
+    var strategies = initStrategies(bodyBuffer);
+
+    var strategy = strategies[params.type] || strategies['default'];  
+
+    try {
+        return strategy(params.charset);    
+    } catch (err) {
+        // Might be nice to do some logging here.
+        return null;
+    }
+}
+
+/**
+ * Simplifies the interface for getting a clean content-type & charset header value.
+ * @param  {string} headerValue A header value to clean.
+ * @return {object|undefined} A clean representation of the input value, or undefined
+ */
+function getConversionParams(headers) {
+    if (!headers['content-type']) return {};
+    var charset = headers['charset'] ? normalize(headers['charset']) : "";
+    var headerSplit = headers['content-type'].split(';');
+    var contentType = normalize(headerSplit[0]);
+
+    // Supports charset as a part of the 'content-type' header.
+    if (!charset && headerSplit[1]) {
+        var charsetIndex = headerSplit[1].indexOf('=');
+        if (charsetIndex !== -1) {
+            charset = normalize(headerSplit[1].substr(charsetIndex+1));
+        }
+    }
+    return {
+        charset: charset || 'utf8',
+        type: contentType
+    };
+}
+
+/**
+ * Removes any '/' or '-' present in the string and returns it.
+ * @param  {string} value A string that should be cleaned of the chars '/' and '-'.
+ * @return {string}       The input string minus some special characters.
+ */
+function normalize(value) {
+    return value.toLowerCase().replace(/[/-]/g, '');
+}
+
+module.exports = {
+    parse: parse
+}
+
+

--- a/lib/bufferParser.js
+++ b/lib/bufferParser.js
@@ -26,14 +26,13 @@ function initStrategies(buffer) {
  * Parses the a buffer into the expected internal type, based
  * on standard request headers (content-type and charset). 
  * 
- * @param  {buffer} bodyBuffer The initial buffer value to parse.
+ * @param  {buffer} buff The initial buffer value to parse.
  * @param  {object} headers Used to select the conversion strategy.
  * @return {object} Parsed post-body according to content-type and charset.
  */
-function parse(bodyBuffer, headers) {
+function parse(buff, headers) {
     var params = getConversionParams(headers);
-    var strategies = initStrategies(bodyBuffer);
-
+    var strategies = initStrategies(buff);
     var strategy = strategies[params.type] || strategies['default'];  
 
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -373,25 +373,13 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         var req    = this;
         var conversionStrategies = {
             applicationjson: function(charset) {
-                try {
-                    return JSON.parse(req.rawBody.toString(charset));
-                } catch (err) {
-                    return null;
-                }
+                return JSON.parse(req.rawBody.toString(charset));
             },
             textplain: function(charset) {
-                try {
-                    return req.rawBody.toString(charset);
-                } catch (err) {
-                    return null;
-                }
+                return req.rawBody.toString(charset);
             },
             texthtml: function(charset) {
-                try {
-                    return req.rawBody.toString(charset);
-                } catch (err) {
-                    return null;
-                }
+                return req.rawBody.toString(charset);
             },
             default: function() {
                 return req.rawBody;
@@ -400,7 +388,11 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
 
         var strategy = conversionStrategies[params.type] || conversionStrategies['default'];  
 
-        return strategy(params.charset);
+        try {
+            return strategy(params.charset);    
+        } catch (err) {
+            return null;
+        }
     }
 
     /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -373,20 +373,25 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         var req    = this;
         var conversionStrategies = {
             applicationjson: function(charset) {
-                var model;
                 try {
-                    model = JSON.parse(req.rawBody.toString(charset));
+                    return JSON.parse(req.rawBody.toString(charset));
+                } catch (err) {
+                    return null;
                 }
-                catch (error) {
-                    throw new Error('Tried to call JSON.parse() on invalid string item: "rawBody"');           
-                }
-                return model;
             },
             textplain: function(charset) {
-                return req.rawBody.toString(charset);
+                try {
+                    return req.rawBody.toString(charset);
+                } catch (err) {
+                    return null;
+                }
             },
             texthtml: function(charset) {
-                return req.rawBody.toString(charset);
+                try {
+                    return req.rawBody.toString(charset);
+                } catch (err) {
+                    return null;
+                }
             },
             default: function() {
                 return req.rawBody;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -335,6 +335,8 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         this.headers = extendObject({}, props.headers || {});
         this.upgrade = props.upgrade || false;
         this.rawBody = props.rawBody || new Buffer("");
+        this.body    = this._parseBody();
+        
         try {
             this.bodyParams = qs.parse(this.rawBody.toString());
         } catch (e) {
@@ -355,7 +357,79 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         }
     }
 
+    /**
+     * Automatically parses the 'Request.rawBody' property into the expected
+     * internal type for usage as the 'Request.body'. 
+     *
+     * To extend the conversion behaviour for more headers, just add a new kvp.
+     * 
+     * * Key should be the name of a header, without / and -
+     * * Value should be a function which returns the body.
+     * 
+     * @return {object} Parsed post-body according to content-type and charset.
+     */
+    Request.prototype._parseBody = function() {
+        var params = getHeaderInfo(this.headers);
+        var req    = this;
+        var conversionStrategies = {
+            applicationjson: function(charset) {
+                var model;
+                try {
+                    model = JSON.parse(req.rawBody.toString(charset));
+                }
+                catch (error) {
+                    throw new Error('Tried to call JSON.parse() on invalid string item: "rawBody"');           
+                }
+                return model;
+            },
+            textplain: function(charset) {
+                return req.rawBody.toString(charset);
+            },
+            texthtml: function(charset) {
+                return req.rawBody.toString(charset);
+            },
+            default: function() {
+                return req.rawBody;
+            }
+        };
 
+        var strategy = conversionStrategies[params.type] || conversionStrategies['default'];  
+
+        return strategy(params.charset);
+    }
+
+    /**
+     * Simplifies the interface for getting a clean content-type & charset header value.
+     * @param  {string} headerValue A header value to clean.
+     * @return {object|undefined} A clean representation of the input value, or undefined
+     */
+    function getHeaderInfo(headers) {
+        if (!headers['content-type']) return {};
+        var charset = headers['charset'] ? normalize(headers['charset']) : "";
+        var headerSplit = headers['content-type'].split(';');
+        var contentType = normalize(headerSplit[0]);
+
+        // Supports charset as a part of the 'content-type' header.
+        if (!charset && headerSplit[1]) {
+            var charsetIndex = headerSplit[1].indexOf('=');
+            if (charsetIndex !== -1) {
+                charset = normalize(headerSplit[1].substr(charsetIndex+1));
+            }
+        }
+        return {
+            charset: charset || 'utf8',
+            type: contentType
+        };
+    }
+
+    /**
+     * Removes any '/' or '-' present in the string and returns it.
+     * @param  {string} value A string that should be cleaned of the chars '/' and '-'.
+     * @return {string}       The input string minus some special characters.
+     */
+    function normalize(value) {
+        return value.toLowerCase().replace(/[/-]/g, '');
+    }
 
     /**
      * Represents a server response.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,8 @@ var url   = require('url'),
     fs    = require('fs'),
     qs    = require('qs'),
     mime  = require('mime');
-var exceptions = require('./exceptions'),
+var bufferParser = require('./bufferParser'),
+    exceptions   = require('./exceptions'),
     InvalidRoboHydraRequestException =
         exceptions.InvalidRoboHydraRequestException,
     InvalidRoboHydraResponseException =
@@ -335,7 +336,7 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         this.headers = extendObject({}, props.headers || {});
         this.upgrade = props.upgrade || false;
         this.rawBody = props.rawBody || new Buffer("");
-        this.body    = this._parseBody();
+        this.body    = bufferParser.parse(this.rawBody, this.headers)
         
         try {
             this.bodyParams = qs.parse(this.rawBody.toString());
@@ -355,77 +356,6 @@ var VALID_CONFIG_KEYS = ["plugins", "pluginConfigDefaults",
         if (this.url === undefined) {
             throw new InvalidRoboHydraRequestException('url', this.url);
         }
-    }
-
-    /**
-     * Automatically parses the 'Request.rawBody' property into the expected
-     * internal type for usage as the 'Request.body'. 
-     *
-     * To extend the conversion behaviour for more headers, just add a new kvp.
-     * 
-     * * Key should be the name of a header, without / and -
-     * * Value should be a function which returns the body.
-     * 
-     * @return {object} Parsed post-body according to content-type and charset.
-     */
-    Request.prototype._parseBody = function() {
-        var params = getHeaderInfo(this.headers);
-        var req    = this;
-        var conversionStrategies = {
-            applicationjson: function(charset) {
-                return JSON.parse(req.rawBody.toString(charset));
-            },
-            textplain: function(charset) {
-                return req.rawBody.toString(charset);
-            },
-            texthtml: function(charset) {
-                return req.rawBody.toString(charset);
-            },
-            default: function() {
-                return req.rawBody;
-            }
-        };
-
-        var strategy = conversionStrategies[params.type] || conversionStrategies['default'];  
-
-        try {
-            return strategy(params.charset);    
-        } catch (err) {
-            return null;
-        }
-    }
-
-    /**
-     * Simplifies the interface for getting a clean content-type & charset header value.
-     * @param  {string} headerValue A header value to clean.
-     * @return {object|undefined} A clean representation of the input value, or undefined
-     */
-    function getHeaderInfo(headers) {
-        if (!headers['content-type']) return {};
-        var charset = headers['charset'] ? normalize(headers['charset']) : "";
-        var headerSplit = headers['content-type'].split(';');
-        var contentType = normalize(headerSplit[0]);
-
-        // Supports charset as a part of the 'content-type' header.
-        if (!charset && headerSplit[1]) {
-            var charsetIndex = headerSplit[1].indexOf('=');
-            if (charsetIndex !== -1) {
-                charset = normalize(headerSplit[1].substr(charsetIndex+1));
-            }
-        }
-        return {
-            charset: charset || 'utf8',
-            type: contentType
-        };
-    }
-
-    /**
-     * Removes any '/' or '-' present in the string and returns it.
-     * @param  {string} value A string that should be cleaned of the chars '/' and '-'.
-     * @return {string}       The input string minus some special characters.
-     */
-    function normalize(value) {
-        return value.toLowerCase().replace(/[/-]/g, '');
     }
 
     /**

--- a/test/robohydra-test.js
+++ b/test/robohydra-test.js
@@ -1450,6 +1450,26 @@ describe("Request object", function() {
             expect(req.body).toEqual(obj);
         });
 
+        it("With a content-type of 'application/json', and invalid JSON, it will be null", function() {
+            var data = new Buffer('banana');
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'application/json' }});
+
+            expect(req.body).toEqual(null);
+        });
+
+        it("With a content-type of 'application/json', but invalid 'charset' it will be null", function() {
+            var obj = { a: 'banana' };
+            var data = new Buffer(JSON.stringify(obj));
+             var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'application/json',
+                                             'charset': 'utf-16' }});
+
+            expect(req.body).toEqual(null);
+        });
+
         it("With a content-type of 'text/html', it will be a valid string", function() {
             var data = new Buffer("<h2>Some</h2> <h1>html-marked-up</h1> <b>text</b>");
             var req = new Request({url: '/foo/bar',
@@ -1499,6 +1519,29 @@ describe("Request object", function() {
                                              'charset': targetCharset }});
 
             expect(req.body).toEqual(data.toString(targetCharset.replace('-', '')));
+        });
+
+        it("Will return null & not freak out if the charset is invalid", function() {
+            var targetCharset = 'bananas';
+            var data = new Buffer("Some plaintext");
+            var plainreq;
+            var htmlreq;
+            
+            expect(function() {
+                plainreq = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/plain',
+                                             'charset': targetCharset }});    
+            }).not.toThrow();
+            expect(plainreq.body).toEqual(null)
+
+            expect(function() {
+                htmlreq = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/html',
+                                             'charset': targetCharset }});    
+            }).not.toThrow();
+            expect(htmlreq.body).toEqual(null)
         });
     });
 });

--- a/test/robohydra-test.js
+++ b/test/robohydra-test.js
@@ -1420,6 +1420,87 @@ describe("Request object", function() {
         var req = new Request({url: '/foo/bar', method: 'PoSt'});
         expect(req.method).toEqual('POST');
     });
+
+    describe("Body property", function() {
+
+        it("Without any content-type header, it will be a buffer of the post-body", function() {
+            var data = new Buffer("Here is some data");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data});
+
+            expect(req.body).toEqual(data);
+        });
+
+        it("With an invalid content-type, it will be a buffer of the post-body", function() {
+            var data = new Buffer("Here is some data");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'ARGLEBARGLE' }});
+
+            expect(req.body).toEqual(data);
+        });
+
+        it("With a content-type of 'application/json', it will be a valid js object", function() {
+            var obj = { a: 'banana' };
+            var data = new Buffer(JSON.stringify(obj));
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'application/json' }});
+
+            expect(req.body).toEqual(obj);
+        });
+
+        it("With a content-type of 'text/html', it will be a valid string", function() {
+            var data = new Buffer("<h2>Some</h2> <h1>html-marked-up</h1> <b>text</b>");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/html'}});
+
+            expect(req.body).toEqual(data.toString());
+        });
+
+        it("With a content-type of 'text/plain', it will be a valid string", function() {
+            var data = new Buffer("Some plaintext");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/plain'}});
+
+            expect(req.body).toEqual(data.toString());
+        });
+
+        it("Will handle a 2-part content-type header without crashing", function() {
+            var data = new Buffer("Some plaintext");
+
+            expect(function() {
+                new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/plain;charset=UTF-8' }});
+            }).not.toThrow();
+        });
+
+        it("Will use the charset specified in the charset header", function() {
+            var targetCharset = 'utf-8';
+            var data = new Buffer("Some plaintext");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/plain',
+                                             'charset': targetCharset }});
+
+            expect(req.body).toEqual(data.toString(targetCharset.replace('-', '')));  
+        });
+
+        it("Will give priority to the value specified in the charset header", function() {
+            var targetCharset = 'utf-8';
+            var charsetToAvoid = 'UTF-16';
+            var data = new Buffer("Some plaintext");
+            var req = new Request({url: '/foo/bar',
+                                   rawBody: data,
+                                   headers: {'content-type': 'text/plain;charset=' + charsetToAvoid,
+                                             'charset': targetCharset }});
+
+            expect(req.body).toEqual(data.toString(targetCharset.replace('-', '')));
+        });
+    });
 });
 
 describe("Response object", function() {


### PR DESCRIPTION
Autoparse will do the following:

* Intercept the 'content-type' and 'charset' headers
* Create a new property: 'body' on the request object
* Assign a value to 'body' according to the 'content-type' and 'charset' headers.

This means that for requests with 'application/json' (I'm guessing this is 90% of all use cases), you'll have ready-to-use property that matches the post-body of the request, instead of having to manually convert the rawBody buffer into a usable object inside the request handler of each head.

I included converters for 'text/html' and 'text/plain', but of course most situations will just be converting the buffer to a string.

Default behaviour (no content-type header, or a value that isn't understood) is to provide a buffer just like the RawBody property, so it should follow the same bahaviour of rawBody in those cases.

Please let me know if i missed something or if you have an issue with the implementation.

/Ben